### PR TITLE
Stricter checking for versioned secret names

### DIFF
--- a/pkg/versionedsecretstore/versioned_secret.go
+++ b/pkg/versionedsecretstore/versioned_secret.go
@@ -23,6 +23,12 @@ func IsVersionedSecret(secret corev1.Secret) bool {
 	return false
 }
 
+var nameRegex = regexp.MustCompile(`^\S+-v(\d+)$`)
+
+func IsVersionedSecretName(name string) bool {
+	return len(nameRegex.FindStringSubmatch(name)) > 0
+}
+
 // NamePrefix returns the name prefix of a versioned secret name, by removing the
 // version suffix /-v\d+/
 func NamePrefix(name string) string {
@@ -30,10 +36,11 @@ func NamePrefix(name string) string {
 	if n < 1 {
 		return ""
 	}
+	if !IsVersionedSecretName(name) {
+		return ""
+	}
 	return name[:n]
 }
-
-var nameRegex = regexp.MustCompile(`^\S+-v(\d+)$`)
 
 // VersionFromName gets version from versioned secret name
 // return -1 if not find valid version

--- a/pkg/versionedsecretstore/versioned_secret_store.go
+++ b/pkg/versionedsecretstore/versioned_secret_store.go
@@ -77,7 +77,6 @@ func NewVersionedSecretStore(client client.Client) VersionedSecretImpl {
 func (p VersionedSecretImpl) SetSecretReferences(ctx context.Context, namespace string, podSpec *corev1.PodSpec) error {
 	_, secretsInSpec := GetConfigNamesFromSpec(*podSpec)
 	for secretNameInSpec := range secretsInSpec {
-
 		versionedSecretPrefix := NamePrefix(secretNameInSpec)
 		// If this secret doesn't look like a versioned secret (e.g. <name>-v2), move on
 		if versionedSecretPrefix == "" {


### PR DESCRIPTION
`SetSecretReferences` was trying to use every secret with a dash as a versioned secret:

`2019-10-31T14:27:08.312Z	DEBUG	ext-job-errand-reconciler	versionedsecretstore/versioned_secret_store.go:93	versioned secret persist-output-service-account-token in namespace test1572531833-304 doesn't exist`


Not harmful, but still.