### PR TITLE
Do not bump identical secrets 

### DIFF
--- a/pkg/versionedsecretstore/versioned_secret.go
+++ b/pkg/versionedsecretstore/versioned_secret.go
@@ -72,6 +72,34 @@ func ContainsSecretName(names []string, name string) bool {
 	return false
 }
 
+// ContainsOutdatedSecretVersion checks if the current secret version is greater
+// than the versions in the secrets list
+func ContainsOutdatedSecretVersion(names []string, name string) bool {
+	unversioned := NamePrefix(name)
+	if unversioned == "" {
+		return false
+	}
+
+	ourVersion, err := VersionFromName(name)
+	if err != nil {
+		return false
+	}
+
+	for _, k := range names {
+		if strings.Contains(k, unversioned) {
+			listVersion, err := VersionFromName(k)
+			if err != nil {
+				continue
+			}
+
+			if ourVersion > listVersion {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // IsInitialVersion returns true if it's a v1 secret
 func IsInitialVersion(secret corev1.Secret) bool {
 	version, ok := secret.Labels[LabelVersion]

--- a/pkg/versionedsecretstore/versioned_secret_store.go
+++ b/pkg/versionedsecretstore/versioned_secret_store.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
@@ -78,6 +79,13 @@ type VersionedSecretImpl struct {
 func NewVersionedSecretStore(client client.Client) VersionedSecretImpl {
 	return VersionedSecretImpl{
 		backend: &versionedSecretStoreClientBackend{client: client},
+	}
+}
+
+// NewClientsetVersionedSecretStore returns a VersionedSecretStore using a kubernetes.Clientset backend
+func NewClientsetVersionedSecretStore(clientset kubernetes.Interface) VersionedSecretImpl {
+	return VersionedSecretImpl{
+		backend: &versionedSecretStoreClientsetBackend{clientset: clientset},
 	}
 }
 

--- a/pkg/versionedsecretstore/versioned_secret_store_backends.go
+++ b/pkg/versionedsecretstore/versioned_secret_store_backends.go
@@ -1,0 +1,46 @@
+package versionedsecretstore
+
+import (
+       "golang.org/x/net/context"
+
+       corev1 "k8s.io/api/core/v1"
+       "k8s.io/apimachinery/pkg/types"
+       "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type versionedSecretStoreClientBackend struct {
+       client client.Client
+}
+
+func (b *versionedSecretStoreClientBackend) Create(ctx context.Context, secret *corev1.Secret) error {
+       return b.client.Create(ctx, secret)
+}
+
+func (b *versionedSecretStoreClientBackend) Get(ctx context.Context, nn types.NamespacedName) (*corev1.Secret, error) {
+       secret := &corev1.Secret{}
+       err := b.client.Get(ctx, nn, secret)
+       if err != nil {
+               return nil, err
+       }
+       return secret, nil
+}
+
+func (b *versionedSecretStoreClientBackend) Update(ctx context.Context, secret *corev1.Secret) error {
+       return b.client.Update(ctx, secret)
+}
+
+func (b *versionedSecretStoreClientBackend) Delete(ctx context.Context, secret *corev1.Secret) error {
+       return b.client.Delete(ctx, secret)
+}
+
+func (b *versionedSecretStoreClientBackend) List(ctx context.Context, namespace string, matchLabels map[string]string) (*corev1.SecretList, error) {
+       secrets := &corev1.SecretList{}
+
+       err := b.client.List(
+               ctx,
+               secrets,
+               client.InNamespace(namespace),
+               client.MatchingLabels(matchLabels),
+       )
+       return secrets, err
+}

--- a/pkg/versionedsecretstore/versioned_secret_store_backends.go
+++ b/pkg/versionedsecretstore/versioned_secret_store_backends.go
@@ -1,46 +1,80 @@
 package versionedsecretstore
 
 import (
-       "golang.org/x/net/context"
+	"golang.org/x/net/context"
 
-       corev1 "k8s.io/api/core/v1"
-       "k8s.io/apimachinery/pkg/types"
-       "sigs.k8s.io/controller-runtime/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type versionedSecretStoreClientsetBackend struct {
+	clientset kubernetes.Interface
+}
+
+func (b *versionedSecretStoreClientsetBackend) Create(ctx context.Context, secret *corev1.Secret) error {
+	_, err := b.clientset.CoreV1().Secrets(secret.Namespace).Create(secret)
+	return err
+}
+
+func (b *versionedSecretStoreClientsetBackend) Get(ctx context.Context, nn types.NamespacedName) (*corev1.Secret, error) {
+	return b.clientset.CoreV1().Secrets(nn.Namespace).Get(nn.Name, metav1.GetOptions{})
+}
+
+func (b *versionedSecretStoreClientsetBackend) Update(ctx context.Context, secret *corev1.Secret) error {
+	_, err := b.clientset.CoreV1().Secrets(secret.Namespace).Update(secret)
+	return err
+}
+
+func (b *versionedSecretStoreClientsetBackend) Delete(ctx context.Context, secret *corev1.Secret) error {
+	err := b.clientset.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+	return err
+}
+
+func (b *versionedSecretStoreClientsetBackend) List(ctx context.Context, namespace string, matchLabels map[string]string) (*corev1.SecretList, error) {
+
+	secrets, err := b.clientset.CoreV1().Secrets(namespace).List(metav1.ListOptions{
+		LabelSelector: labels.Set(matchLabels).String(),
+	})
+	return secrets, err
+}
+
 type versionedSecretStoreClientBackend struct {
-       client client.Client
+	client client.Client
 }
 
 func (b *versionedSecretStoreClientBackend) Create(ctx context.Context, secret *corev1.Secret) error {
-       return b.client.Create(ctx, secret)
+	return b.client.Create(ctx, secret)
 }
 
 func (b *versionedSecretStoreClientBackend) Get(ctx context.Context, nn types.NamespacedName) (*corev1.Secret, error) {
-       secret := &corev1.Secret{}
-       err := b.client.Get(ctx, nn, secret)
-       if err != nil {
-               return nil, err
-       }
-       return secret, nil
+	secret := &corev1.Secret{}
+	err := b.client.Get(ctx, nn, secret)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
 }
 
 func (b *versionedSecretStoreClientBackend) Update(ctx context.Context, secret *corev1.Secret) error {
-       return b.client.Update(ctx, secret)
+	return b.client.Update(ctx, secret)
 }
 
 func (b *versionedSecretStoreClientBackend) Delete(ctx context.Context, secret *corev1.Secret) error {
-       return b.client.Delete(ctx, secret)
+	return b.client.Delete(ctx, secret)
 }
 
 func (b *versionedSecretStoreClientBackend) List(ctx context.Context, namespace string, matchLabels map[string]string) (*corev1.SecretList, error) {
-       secrets := &corev1.SecretList{}
+	secrets := &corev1.SecretList{}
 
-       err := b.client.List(
-               ctx,
-               secrets,
-               client.InNamespace(namespace),
-               client.MatchingLabels(matchLabels),
-       )
-       return secrets, err
+	err := b.client.List(
+		ctx,
+		secrets,
+		client.InNamespace(namespace),
+		client.MatchingLabels(matchLabels),
+	)
+	return secrets, err
 }


### PR DESCRIPTION
This pr makes it possible to use the VersionedSecretStore with a kubernetes.Clientset instead of a client.Client, e.g. in operator subcommands where a client.Client is not available.

It also changes the VersionedSecretStore to not create new versions of a secret if the secret is unchanged from the previous version.

Dependent PR's
1. https://github.com/cloudfoundry-incubator/quarks-job/pull/21
2. https://github.com/cloudfoundry-incubator/cf-operator/pull/652