### PR TITLE
Add quarks link naming functions

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -62,15 +62,19 @@ func DesiredManifestName(deploymentName string, version string) string {
 	return finalName
 }
 
-// EntanglementSecretName returns the name of a secret containing properties of
-// the provides section from a BOSH job
-func EntanglementSecretName(deploymentName, igName string) string {
-	return Sanitize(fmt.Sprintf("link-%s-%s", deploymentName, igName))
+// QuarksLinkSecretName returns the name of a secret used for Quarks links
+// to be mounted or used by environment variables
+func QuarksLinkSecretName(deploymentName string, suffixes ...string) string {
+	return Sanitize(strings.Join(
+		append([]string{"link", deploymentName}, suffixes...),
+		"-",
+	))
 }
 
-// EntanglementSecretKey returns the key (composed of type and name) for the k8s secret's data
-func EntanglementSecretKey(linkType, linkName string) string {
-	return fmt.Sprintf("%s.%s", linkType, linkName)
+// QuarksLinkSecretKey returns the key (composed of type and name), which is
+// used as the root level key for the data mapping in secrets
+func QuarksLinkSecretKey(linkType, linkName string) string {
+	return fmt.Sprintf("%s-%s", linkType, linkName)
 }
 
 var secretNameRegex = regexp.MustCompile("[^-][a-z0-9-]*.[a-z0-9-]*[^-]")

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -106,4 +106,26 @@ var _ = Describe("Names", func() {
 			}
 		})
 	})
+
+	Context("QuarksLink related names", func() {
+		Context("link type and name strings", func() {
+			It("should return a simple link type and link name string", func() {
+				Expect(names.QuarksLinkSecretKey("type", "name")).To(Equal("type-name"))
+			})
+		})
+
+		Context("link secret name strings", func() {
+			It("should return a string to be used as a secret name for links without a suffix", func() {
+				Expect(names.QuarksLinkSecretName("deploymentname")).To(Equal("link-deploymentname"))
+			})
+
+			It("should return a string to be used as a secret name for links with one suffix", func() {
+				Expect(names.QuarksLinkSecretName("deploymentname", "suffix")).To(Equal("link-deploymentname-suffix"))
+			})
+
+			It("should return a string to be used as a secret name for links with multiple suffixes", func() {
+				Expect(names.QuarksLinkSecretName("deploymentname", "one", "two")).To(Equal("link-deploymentname-one-two"))
+			})
+		})
+	})
 })


### PR DESCRIPTION
[#170725085](https://www.pivotaltracker.com/story/show/170725085)

With changes to the Quarks Link setup, the `EntanglementSecretName`
function signature became a bit misleading and `EntanglementSecretKey`
required a slight change in order to be used as a Kube name reference.

Introduce replacement functions for Quarks Link related naming helpers.