### PR TITLE
Add a 10s timeout to WaitForPort

### DIFF
--- a/testing/testhelper/wait_for_port.go
+++ b/testing/testhelper/wait_for_port.go
@@ -19,7 +19,7 @@ func WaitForPort(host, port string, timeOut time.Duration) error {
 			defer wg.Done()
 			for {
 				t := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-				client := &http.Client{Transport: t}
+				client := &http.Client{Transport: t, Timeout: 10 * time.Second}
 				r, err := client.Get(fmt.Sprintf("https://%s/readyz", address))
 				if err == nil && r.StatusCode == 200 {
 					return


### PR DESCRIPTION
TCP connection attempts may time out after minutes, i.e. if the
handshake is silently dropped.