### PR TITLE
Add WaitForPodCount integration helper

### DIFF
--- a/testing/machine/pod.go
+++ b/testing/machine/pod.go
@@ -49,6 +49,19 @@ func (m *Machine) WaitForPods(namespace string, labels string) error {
 	})
 }
 
+// WaitForPodCount blocks until the specified number of pods is running
+func (m *Machine) WaitForPodCount(namespace string, labels string, count int) error {
+	return wait.PollImmediate(m.PollInterval, m.PollTimeout, func() (bool, error) {
+		n, err := m.PodCount(namespace, labels, func(pod corev1.Pod) bool {
+			return pod.Status.Phase == corev1.PodRunning
+		})
+		if err != nil {
+			return false, err
+		}
+		return n == count, nil
+	})
+}
+
 // WaitForPodFailures blocks until all selected pods are failing. It fails after the timeout.
 func (m *Machine) WaitForPodFailures(namespace string, labels string) error {
 	return wait.PollImmediate(5*time.Second, m.PollTimeout, func() (bool, error) {


### PR DESCRIPTION
Similar to the existing Eventually blocks in qsts

https://github.com/cloudfoundry-incubator/quarks-statefulset/blob/a70722cdb13d8ea51b2566c5f1e7d9b6f2df01f5/integration/quarks_statefulset_test.go#L352-L358