### PR TITLE
RestartOperator doesn't use namespaced name

### DIFF
--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -470,8 +470,7 @@ func SecretCheckData(namespace string, secretName string, fieldPath string) erro
 
 // RestartOperator restart Operator Deployment
 func RestartOperator(namespace string) error {
-	deploymentName := fmt.Sprintf("deployment/%s-%s", QuarksHelmRelease, namespace)
-	fmt.Println("Restarting '" + deploymentName + "'...")
+	deploymentName := fmt.Sprintf("deployment/%s", QuarksHelmRelease)
 
 	_, err := runBinary(kubeCtlCmd, "patch", deploymentName,
 		"--namespace", namespace, "--patch", "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"dummy-date\":\"`date +'%s'`\"}}}}}")


### PR DESCRIPTION
Prefixes were removed in quarks-operator


[#175984792](https://www.pivotaltracker.com/story/show/175984792)